### PR TITLE
feat: add option for omitting function key/value in the debugger

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
   "root": true,
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/consistent-type-assertions": "off"
+    "@typescript-eslint/consistent-type-assertions": "off",
+    "@typescript-eslint/strict-boolean-expressions": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reactotron-plugin-zustand",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reactotron-plugin-zustand",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.3.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,10 +58,7 @@ export default function reactotronPluginZustand({
           reactotron.send('state.backup.response', {
             state: stores.map((item) => ({
               path: item.name,
-              value: omitFunctionRecursively(
-                item.store.getState(),
-                true // always backup without functions
-              )
+              value: item.store.getState()
             }))
           });
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,10 @@ export default function reactotronPluginZustand({
           reactotron.send('state.backup.response', {
             state: stores.map((item) => ({
               path: item.name,
-              value: item.store.getState()
+              value: omitFunctionRecursively(
+                item.store.getState(),
+                true // always backup without functions
+              )
             }))
           });
         }


### PR DESCRIPTION
Basically, there were situations where it was difficult to grasp the values at a glance in the debugger due to the functions being displayed, so we added an option to remove them.

This is set to true by default, and in the backup, the functions will always be excluded from the backup according to the original logic.

Please let me know your thoughts on this.

```ts
   .use(
      //add this line 🙌
      reactotronZustand({
        stores: [
          { name: 'curriculum', store: useCurriculum },
          { name: 'lesson', store: useLesson },
          { name: 'user', store: useUser },
        ],
        omitFunctionKeys: true, // default: true
      }),
    )
```