### PR TITLE
fix: add bypass case for Date when omitFunctionKeys is true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reactotron-plugin-zustand",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reactotron-plugin-zustand",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.3.1"

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { omitFunctionRecursively } from '../utils';
 
+const testDate = new Date();
+
 describe('omitFunctionRecursively', () => {
   it('should return the input as is when enable is false', () => {
-    const input = { a: 1, b: () => {}, c: { d: 2 } };
+    const input = { a: 1, b: () => {}, c: { d: 2 }, d: testDate };
 
     const result = omitFunctionRecursively(input, false);
 
@@ -11,9 +13,14 @@ describe('omitFunctionRecursively', () => {
   });
 
   it('should omit functions from an object', () => {
-    const input = { a: 1, b: () => {}, c: { d: 2, e: () => {} } };
+    const input = {
+      a: 1,
+      b: () => {},
+      c: { d: 2, e: () => {}, f: testDate },
+      g: testDate
+    };
 
-    const expected = { a: 1, c: { d: 2 } };
+    const expected = { a: 1, c: { d: 2, f: testDate }, g: testDate };
 
     const result = omitFunctionRecursively(input, true);
 
@@ -21,9 +28,9 @@ describe('omitFunctionRecursively', () => {
   });
 
   it('should omit functions from an array', () => {
-    const input = [1, () => {}, { a: 2, b: () => {} }];
+    const input = [1, () => {}, { a: 2, b: () => {}, c: testDate }, testDate];
 
-    const expected = [1, { a: 2 }];
+    const expected = [1, { a: 2, c: testDate }, testDate];
 
     const result = omitFunctionRecursively(input, true);
 
@@ -31,9 +38,12 @@ describe('omitFunctionRecursively', () => {
   });
 
   it('should handle nested structures', () => {
-    const input = { a: 1, b: { c: () => {}, d: { e: 2, f: () => {} } } };
+    const input = {
+      a: 1,
+      b: { c: () => {}, d: { e: 2, f: () => {}, g: testDate } }
+    };
 
-    const expected = { a: 1, b: { d: { e: 2 } } };
+    const expected = { a: 1, b: { d: { e: 2, g: testDate } } };
 
     const result = omitFunctionRecursively(input, true);
 
@@ -41,9 +51,12 @@ describe('omitFunctionRecursively', () => {
   });
 
   it('should handle arrays within objects', () => {
-    const input = { a: [1, () => {}, 2], b: { c: [3, () => {}, 4] } };
+    const input = {
+      a: [1, () => {}, 2, testDate],
+      b: { c: [3, () => {}, 4, testDate] }
+    };
 
-    const expected = { a: [1, 2], b: { c: [3, 4] } };
+    const expected = { a: [1, 2, testDate], b: { c: [3, 4, testDate] } };
 
     const result = omitFunctionRecursively(input, true);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ export function omitFunctionRecursively<T>(input: T, enable: boolean): T {
 }
 
 function removeFunctions(value: any): any {
-  if (typeof value !== 'object' || value === null) {
+  if (typeof value !== 'object' || value === null || value instanceof Date) {
     return value;
   }
 
@@ -15,10 +15,6 @@ function removeFunctions(value: any): any {
     return value
       .map(removeFunctions)
       .filter((item) => typeof item !== 'function');
-  }
-
-  if (value instanceof Date) {
-    return value;
   }
 
   const newObj: any = {};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,10 @@ function removeFunctions(value: any): any {
       .filter((item) => typeof item !== 'function');
   }
 
+  if (value instanceof Date) {
+    return value;
+  }
+
   const newObj: any = {};
 
   for (const key in value) {


### PR DESCRIPTION
currently, if `omitFunctionKey === true`, the `removeFunctions` function treats `Date` objects as a regular object, and remove all details from it:

<img width="399" height="71" alt="image" src="https://github.com/user-attachments/assets/fd47b829-c076-46bb-8c96-babe9a7d9ee6" />


this PR changes `removeFunctions` to check if the value is an instance of `Date` (by using `instanceof`)  and if so, returns the value unchanged.


After changes:

<img width="500" height="67" alt="image" src="https://github.com/user-attachments/assets/d1c849ea-b50d-4b9e-bbe1-a589425cb093" />

